### PR TITLE
floating menu button bug

### DIFF
--- a/src/components/floating-menu-button.js
+++ b/src/components/floating-menu-button.js
@@ -6,7 +6,7 @@ import { FloatingMenu } from "../components/dashboard/floating-menu"
 import { Colors } from "../util/colors"
 
 const Button = styled.div`
-    position: absolute;
+    position: fixed;
     width: 62px;
     height: 62px;
     right: 64px;


### PR DESCRIPTION
**Ticket:** [Short Ticket Description](url)
the floating menu button would get stuck on the screen after scrolling up or changing the window size.

**Changes Made:**
- {Bullet-Pointed Descriptions of Changes}
- changed the position of the button to "fixed"

**Dependent On:**
- {URLs to PRs}
